### PR TITLE
Fixes two small issues

### DIFF
--- a/examples/SConstruct
+++ b/examples/SConstruct
@@ -91,7 +91,7 @@ env.VariantDir('build/', '../src/')
 src_framework = [env.Object("build/SerialPort.cpp"), env.Object("build/SerialPortLinux.cpp"), env.Object("build/SerialPortMacOS.cpp"), env.Object("build/SerialPortWindows.cpp"),
                  env.Object("build/minitraces.cpp"), env.Object("build/ControlTables.cpp"), env.Object("build/Utils.cpp"), env.Object("build/ControllerAPI.cpp"),env.Object("build/Servo.cpp"),
                  env.Object("build/Dynamixel.cpp"), env.Object("build/DynamixelTools.cpp"), env.Object("build/DynamixelSimpleAPI.cpp"), env.Object("build/DynamixelController.cpp"),
-                 env.Object("build/ServoDynamixel.cpp"), env.Object("build/ServoAX.cpp"), env.Object("build/ServoEX.cpp"), env.Object("build/ServoMX.cpp"), env.Object("build/ServoXL.cpp"), env.Object("build/ServoXL.cpp"),
+                 env.Object("build/ServoDynamixel.cpp"), env.Object("build/ServoAX.cpp"), env.Object("build/ServoEX.cpp"), env.Object("build/ServoMX.cpp"), env.Object("build/ServoXL.cpp"), env.Object("build/ServoX.cpp"),
                  env.Object("build/HerkuleX.cpp"), env.Object("build/HerkuleXTools.cpp"), env.Object("build/HerkuleXSimpleAPI.cpp"), env.Object("build/HerkuleXController.cpp"),
                  env.Object("build/ServoHerkuleX.cpp"), env.Object("build/ServoDRS.cpp")]
 

--- a/src/SerialPortLinux.cpp
+++ b/src/SerialPortLinux.cpp
@@ -55,11 +55,14 @@
 #include <vector>
 #include <thread>
 
+#define SCAN_PORT_TYPES 4
+#define SCAN_PORT_COUNT 8
+
 int serialPortsScanner(std::vector <std::string> &availableSerialPorts)
 {
     int retcode = 0;
     std::string portBase = "/dev/tty";
-    std::string portVariations[4] = {"USB", "ACM", "S", ""};
+    std::string portVariations[SCAN_PORT_TYPES] = {"USB", "ACM", "S", ""};
 
     TRACE_INFO(SERIAL, "serialPortsScanner() [Linux variant]");
 
@@ -68,9 +71,9 @@ int serialPortsScanner(std::vector <std::string> &availableSerialPorts)
     // Regular Serial ports from motherboards (/dev/ttyS*)
     // Regular Serial ports from motherboards (/dev/tty*)
 
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < SCAN_PORT_TYPES; i++)
     {
-        for (int j = 0; j < 8; j++)
+        for (int j = 0; j < SCAN_PORT_COUNT; j++)
         {
             std::string portPath = portBase + portVariations[i] + std::to_string(j);
             std::string portName = "tty" + portVariations[i] + std::to_string(j);


### PR DESCRIPTION
I fixed two small bugs. 
The first one is simple misspelling, "ServoXL.cpp" appears twice in SConstruct file.
The second issue is preventing ttyS* and tty* to be scanned because array and loop cycle size is not equal.