### PR TITLE
Fix compiler warnings about redefining NOMIMNAX macro

### DIFF
--- a/SmartServoFramework/SerialPortWindows.h
+++ b/SmartServoFramework/SerialPortWindows.h
@@ -28,7 +28,9 @@
 #include "SerialPort.h"
 
 // Windows specific
+#ifndef NOMINMAX
 #define NOMINMAX // Not sure if really needed when building the framework without Qt, but still...
+#endif
 #undef UNICODE // Avoid runtime errors when building with MSVC...
 
 #include <windows.h>


### PR DESCRIPTION
On Windows compiling with Mingw + Qt 5.7.0 I got a bunch of the following warnings:
```
../SmartServoFramework/SerialPortWindows.h:31:0: warning: "NOMINMAX" redefined
#define NOMINMAX // Not sure if really needed when building the framework without Qt, but still...
```

so I think it is better to move it between a guard,